### PR TITLE
1.0 provisioning cleanup

### DIFF
--- a/builder/provision.py
+++ b/builder/provision.py
@@ -25,7 +25,9 @@ class BoxProvisioner(BoxAutomator):
     VAGRANT_REPO_URL = 'https://github.com/kubostech/kubos-vagrant'
     DUMP_LOG_LINES = 50 #Number of lines to dump from end of logs on an error
     status_steps = {
-                        'base' :      ['privileged',
+                        'base' :      ['file',
+                                       'privileged',
+                                       'test',
                                        'pre-package'],
                         'kubos-dev' : ['privileged',
                                        'non-privileged',

--- a/kubos-dev/Vagrantfile
+++ b/kubos-dev/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "kubostech/base"
   config.vm.provision "privileged",    type: "shell", path: "./script/privileged-provision.sh"
-  config.vm.provision "non-privilege", type: "shell", path: "./script/non-privileged-provision.sh", privileged: false
+  config.vm.provision "non-privileged", type: "shell", path: "./script/non-privileged-provision.sh", privileged: false
   config.vm.provision "test",          type: "shell", path: "./script/provision-test.sh"
   config.vm.provision "pre-package",   type: "shell", path: "./script/pre-package.sh"
   config.vm.synced_folder ".", "/vagrant"


### PR DESCRIPTION
These are a couple of pretty minor local changes that were previously missed that were required for the 1.0 provisioning.

Once this is merged the repo should get tagged with 1.0.0.

A trello [story](https://trello.com/c/1OcPLf1Q/24-fix-the-kubos-vagrant-release-script) has been created to fix the release script for the API changes that came with today's Vagrant migration, before the next release.