### PR TITLE
Adding toolchain for Pumpkin MBM2

### DIFF
--- a/base/script/privileged-provision.sh
+++ b/base/script/privileged-provision.sh
@@ -48,6 +48,9 @@ echo "Installing KubOS Linux Toolchains"
 apt-get install -y minicom
 apt-get install -y libc6-i386 lib32stdc++6 lib32z1
 
+#Utilities for building KubOS Linux
+apt-get install -y unzip mtools
+
 #iOBC Toolchain
 wget http://portal.kubos.co/bin/iobc_toolchain.tar.gz
 tar -xf /home/vagrant/iobc_toolchain.tar.gz -C /usr/bin
@@ -57,7 +60,6 @@ rm /home/vagrant/iobc_toolchain.tar.gz
 wget http://portal.kubos.co/bin/bbb_toolchain.tar.gz
 tar -xf /home/vagrant/bbb_toolchain.tar.gz -C /usr/bin
 rm /home/vagrant/bbb_toolchain.tar.gz
-
 
 mv /home/vagrant/minirc.kubos /etc/minicom/minirc.kubos
 mv /home/vagrant/minirc.msp430 /etc/minicom/minirc.msp430

--- a/base/script/privileged-provision.sh
+++ b/base/script/privileged-provision.sh
@@ -61,6 +61,9 @@ wget http://portal.kubos.co/bin/bbb_toolchain.tar.gz
 tar -xf /home/vagrant/bbb_toolchain.tar.gz -C /usr/bin
 rm /home/vagrant/bbb_toolchain.tar.gz
 
+#Legacy Beaglebone Black toolchain
+apt-get install crossbuild-essential-armhf gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+
 mv /home/vagrant/minirc.kubos /etc/minicom/minirc.kubos
 mv /home/vagrant/minirc.msp430 /etc/minicom/minirc.msp430
 mv /home/vagrant/kubos-usb.rules /etc/udev/rules.d/kubos-usb.rules

--- a/base/script/privileged-provision.sh
+++ b/base/script/privileged-provision.sh
@@ -43,18 +43,26 @@ pip install sphinxcontrib-plantuml
 pip install sphinx-jsondomain
 
 #KubOS Linux setup
-echo "Installing KubOS Linux Toolchain"
+echo "Installing KubOS Linux Toolchains"
 
 apt-get install -y minicom
 apt-get install -y libc6-i386 lib32stdc++6 lib32z1
 
+#iOBC Toolchain
 wget http://portal.kubos.co/bin/iobc_toolchain.tar.gz
 tar -xf /home/vagrant/iobc_toolchain.tar.gz -C /usr/bin
 rm /home/vagrant/iobc_toolchain.tar.gz
+
+#Beaglebone Black/Pumpkin MBM2 toolchain
+wget http://portal.kubos.co/bin/bbb_toolchain.tar.gz
+tar -xf /home/vagrant/bbb_toolchain.tar.gz -C /usr/bin
+rm /home/vagrant/bbb_toolchain.tar.gz
+
+
 mv /home/vagrant/minirc.kubos /etc/minicom/minirc.kubos
 mv /home/vagrant/minirc.msp430 /etc/minicom/minirc.msp430
 mv /home/vagrant/kubos-usb.rules /etc/udev/rules.d/kubos-usb.rules
-echo "export PATH=/usr/bin/iobc_toolchain/usr/bin:$PATH" >> /etc/profile
+
 adduser vagrant dialout
 
 #Vagrant commands may act funny without password-less sudo

--- a/kubos-dev/Vagrantfile
+++ b/kubos-dev/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     #STM Devices
     ['0x0483', '0x374b', 'STM32 STLink'],
     ['0x0483', '0xdf11', 'STM32 BOOTLOADER'],
-    #iOBC Devices
+    #FTDI Devices
     ['0x0403', '0x6001', 'FTDI']
   ]
   config.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
- Updating the provisioning script to download the new toolchain for KubOS Linux on Beaglebone Black-based boards
- Removing the need to add the toolchains to PATH, since they'll be explicitly specified by the toolchain.cmake files as part of kubostech/kubos#170
- Tweaking comment wording to make things not board-specific

(To-Do: Upload the actual toolchain...)

Update:
- Adding `unzip` and `mtools` to list of things to install during provisioning. They're needed by buildroot while building KubOS Linux
- Adding installs required to build projects for the existing Beaglebone Black Linux, which I have dubbed "Legacy Linux"