### PR TITLE
Automation fixes

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -91,7 +91,7 @@ def main():
                         help='Specify a non-default Vagrant box directory (points to a Vagrantfile or the directory containing the Vagrant file)')
 
     args, following_args = parser.parse_known_args()
-    args.version = args.version[0] #version is initially a list of 1 element
+    args.version = args.version[0] # Version is initially a list of 1 element
     args.box_name = args.box_name[0]
     if args.box_name == 'all':
         args.box_name = 'base'

--- a/builder/main.py
+++ b/builder/main.py
@@ -46,17 +46,20 @@ def main():
                         nargs=1,
                         help='Specify the version of the upload.')
 
-
     resume_parser = parser.add_mutually_exclusive_group(required=False)
     resume_parser.add_argument('--resume', dest='resume', action='store_true')
     resume_parser.add_argument('--no-resume', dest='resume', action='store_false')
     parser.set_defaults(resume=True)
 
-
     parser.add_argument('-a', '--all',
                         action='store_true',
                         default=False,
                         help='Provision, Package and Upload the box to Vagrant Cloud.')
+
+    parser.add_argument('-l', '--local',
+                        action='store_true',
+                        default=False,
+                        help='Run and build with the local repo, rather than cloning the kubos vagrant repo')
 
     parser.add_argument('-c', '--clean',
                         action='store_true',
@@ -66,42 +69,22 @@ def main():
     parser.add_argument('--provision',
                         action='store_true',
                         default=False,
-                        help='Only provision the box but do not package or upload it.')
-
-    parser.add_argument('--provision-no-clone',
-                        action='store_true',
-                        default=False,
-                        help='Provision the box without trying to reclone the repo.')
+                        help='Only provision the box and exit')
 
     parser.add_argument('--package',
                         action='store_true',
                         default=False,
-                        help='Skip provisioning and uploading the box. Only package the box.')
+                        help='Package the box and exit. Skip provisioning and uploading the box.')
 
     parser.add_argument('-u', '--upload',
                         action='store_true',
                         default=False,
                         help='Skip the provisioning and building steps. Only upload the box.')
 
-    parser.add_argument('--upload-no-create-version',
+    parser.add_argument('--halt-release',
                         action='store_true',
                         default=False,
-                        help='Skip creating the version when uploading the box')
-
-    parser.add_argument('--upload-no-create-provider',
-                        action='store_true',
-                        default=False,
-                        help='Skip creating the provider when uploading the box')
-
-    parser.add_argument('--upload-no-box-upload',
-                        action='store_true',
-                        default=False,
-                        help='Skip the box upload step of the upload process')
-
-    parser.add_argument('--upload-no-release',
-                        action='store_true',
-                        default=False,
-                        help='Skip the release step after uploading the box')
+                        help='Do not release after uploading the box.')
 
     parser.add_argument('-b', '--box',
                         default=None,

--- a/builder/package.py
+++ b/builder/package.py
@@ -52,7 +52,7 @@ class BoxPackager(BoxAutomator):
             print 'Packaging completed successfully...'
 
         except subprocess.CalledProcessError as e:
-            print>>sys.stderr, 'Error: The package step failed %s' % e #print the error message from vagrant
+            print>>sys.stderr, 'Error: The package step failed %s' % e # Print the error message from vagrant
             sys.exit(1)
 
 

--- a/builder/provision.py
+++ b/builder/provision.py
@@ -23,7 +23,7 @@ from utils import BoxAutomator
 class BoxProvisioner(BoxAutomator):
     STATUS_KEY = 'provision'
     VAGRANT_REPO_URL = 'https://github.com/kubostech/kubos-vagrant'
-    DUMP_LOG_LINES = 50 #Number of lines to dump from end of logs on an error
+    DUMP_LOG_LINES = 50 # Number of lines to dump from end of logs on an error
     status_steps = {
                         'base' :      ['file',
                                        'privileged',

--- a/builder/provision.py
+++ b/builder/provision.py
@@ -38,7 +38,10 @@ class BoxProvisioner(BoxAutomator):
     def __init__(self, args):
         super(BoxProvisioner, self).__init__(args)
         if self.name == 'kubos-dev':
+            # Pull the latest base box if there's a new one available
+            # Vagrant doesn't allow tagging local boxes with version #'s
             self.update_base_box()
+
 
     def update_base_box(self):
         print 'Updating the base box'
@@ -106,7 +109,10 @@ class BoxProvisioner(BoxAutomator):
 
 def provision_box(args):
     provisioner = BoxProvisioner(args)
-    if not args.provision_no_clone:
+    if args.local:
+        provisioner.copy_box_directory(args.box_name)
+        provisioner.setup_status()
+    else:
         provisioner.clone_vagrant_repo()
     provisioner.provision()
     print 'Provisioning successfully completed...'

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,0 +1,3 @@
+python_vagrant.egg==info
+requests==2.18.4
+GitPython==2.1.7

--- a/builder/upload.py
+++ b/builder/upload.py
@@ -119,7 +119,7 @@ class BoxUploader(BoxAutomator):
             if self.check_status('submit_upload'):
                 print 'Box previously uploaded... Skipping...'
         print 'Uploading box file %s' % self.path
-        #The requests mulitpart file upload is being rejected by the Vagrant API - Just using a curl shell command for now
+        # The requests mulitpart file upload is being rejected by the Vagrant API - Just using a curl shell command for now
         # upload_file = {'file': open(path)}
         # res = requests.put(upload_url, files=upload_file)
         # return res
@@ -154,7 +154,7 @@ def upload_box(args):
     The REST API upload workflow is:
 
     1) Create a new version of the box
-    2) Create a virtualbox provider for the new version
+    2) Create a VirtualBox provider for the new version
     3) Get our upload endpoint and upload token
     4) Upload the *.box file
     5) Release the version
@@ -167,9 +167,9 @@ def upload_box(args):
     errors_key  = 'errors'
 
     uploader.validate_box_path(args)
-    #create the new version
+    # Create the new version
     create_version_response = uploader.create_version()
-    #add the Virtuaox provider
+    # Add the VirtualBox provider
     create_provider_response = uploader.create_provider()
 
     status_response = uploader.get_upload_status()
@@ -182,7 +182,7 @@ def upload_box(args):
     upload_url   = status_data['upload_path']
     upload_token = status_data['token']
 
-    # upload the box file
+    # Upload the box file
     uploader.submit_upload(upload_url)
 
     if not args.halt_release:

--- a/builder/upload.py
+++ b/builder/upload.py
@@ -52,7 +52,7 @@ class BoxUploader(BoxAutomator):
 
     def __init__(self, args):
         super(BoxUploader, self).__init__(args)
-        self.BASE_URL = 'https://atlas.hashicorp.com/api/v1/box/%s/%s' % (self.USER_NAME, self.name)
+        self.BASE_URL = 'https://app.vagrantup.com/api/v1/box/%s/%s' % (self.USER_NAME, self.name)
         self.ACCESS_TOKEN = os.environ['VAGRANT_CLOUD_ACCESS_TOKEN']
         self.setup_status()
 

--- a/builder/upload.py
+++ b/builder/upload.py
@@ -167,10 +167,10 @@ def upload_box(args):
     errors_key  = 'errors'
 
     uploader.validate_box_path(args)
-    if args.all or not args.upload_no_create_version:
-        create_version_response = uploader.create_version()
-    if args.all or not args.upload_no_create_provider:
-        create_provider_response = uploader.create_provider()
+    #create the new version
+    create_version_response = uploader.create_version()
+    #add the Virtuaox provider
+    create_provider_response = uploader.create_provider()
 
     status_response = uploader.get_upload_status()
     status_data = status_response.json()
@@ -182,10 +182,10 @@ def upload_box(args):
     upload_url   = status_data['upload_path']
     upload_token = status_data['token']
 
-    if args.all or not args.upload_no_box_upload:
-        uploader.submit_upload(upload_url)
+    # upload the box file
+    uploader.submit_upload(upload_url)
 
-    if args.all or not args.upload_no_release:
+    if not args.halt_release:
         release_response = uploader.release_version()
         verification_response = uploader.get_version_status()
         hosted_token = verification_response.json()['hosted_token']

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -61,12 +61,12 @@ class BoxAutomator(object):
         return None
 
 
-    def check_status(self, step):
+    def check_status(self, status_step):
         data = self.load_status(self.STATUS_FILE)
         if data == None:
             return None
-        if step in data[self.name][self.STATUS_KEY]:
-            return data[self.name][self.STATUS_KEY][step]
+        if status_step in data[self.name][self.STATUS_KEY]:
+            return data[self.name][self.STATUS_KEY][status_step]
         else:
             return None
 
@@ -202,6 +202,15 @@ class BoxAutomator(object):
             print 'Cleaning existing build directory %s' % self.VERSION_DIR
             shutil.rmtree(self.VERSION_DIR)
             self.setup_dirs()
+
+
+    def copy_box_directory(self, box_name):
+        dest_dir = os.path.join(self.VERSION_DIR, box_name)
+        source_dir = os.path.abspath(os.path.join(__file__, '..', '..', box_name))
+        if os.path.isdir(dest_dir):
+            print 'Destination directory %s already exists... Skipping copy' % dest_dir
+        else:
+            shutil.copytree(source_dir, dest_dir)
 
 
 def clean_build(args):

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -72,7 +72,7 @@ class BoxAutomator(object):
 
 
     def save_status(self, status, path):
-        #status is a json encoded dict
+        # Status is a json encoded dict
         with open(path, 'w') as status_file:
             status_file.write(json.dumps(status))
 
@@ -84,7 +84,7 @@ class BoxAutomator(object):
                 data[self.name] = {}
                 self.save_status(data, self.STATUS_FILE)
         else:
-            #The status file doesn't exist. Create it and add the current box to it.
+            # The status file doesn't exist. Create it and add the current box to it.
             js_data = json.loads('{ "%s" : {} }' % self.name)
             self.save_status(js_data, self.STATUS_FILE)
 
@@ -106,7 +106,7 @@ class BoxAutomator(object):
 
 
     def update_status(self, step):
-        #updating the status upon completion of a step
+        # Updating the status upon completion of a step
         data = self.load_status(self.STATUS_FILE)
         data[self.name][self.STATUS_KEY][step] = True
         self.save_status(data, self.STATUS_FILE)
@@ -116,7 +116,7 @@ class BoxAutomator(object):
     '''
 
     def post_clone_setup(self):
-        #Because cloning requires an empty directory we have to make the log directory at a later time.
+        # Because cloning requires an empty directory we have to make the log directory at a later time.
         self.check_log_dir()
         self.setup_status_file()
 
@@ -169,7 +169,7 @@ class BoxAutomator(object):
         if not path:
             print 'Path was not provided. Using the default path...'
             self.path = os.path.join(os.getcwd(), self.name)
-        if os.path.isfile(self.path): #if it's pointing to a Vagrantfile - we want the directory name
+        if os.path.isfile(self.path): # If it's pointing to a Vagrantfile - we want the directory name
             self.path = os.path.dirname(self.path)
         if not self.VAGRANT_FILE in os.listdir(self.path):
             print >>sys.stderr, 'Error: %s is not a valid path to a Vagrantfile or to a valid box directory' % path
@@ -178,8 +178,8 @@ class BoxAutomator(object):
 
 
     def validate_box_path(self, args):
-        #validate_box_path is only called from the upload file - which requires a valid package.box file
-        #to be functional
+        # Validate_box_path is only called from the upload file - which requires a valid package.box file
+        # to be functional
         self.validate_path(args.box)
         self.box_path = os.path.join(self.path, self.BOX_FILE_NAME)
         if not os.path.isfile(self.box_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python_vagrant==0.5.15
+requests==2.18.4
+GitPython==2.1.7


### PR DESCRIPTION
This should:
- [x] fix the Rest api release automation
- [x] implement the ability for building the local kubos-vagrant repo, to easily test provision changes
- [x] remove a bunch of the confusing and un-needed arguments
- [x] add a requirements.txt
